### PR TITLE
Use full URI for docker registry

### DIFF
--- a/conf/test_raw_immcantation_devel.config
+++ b/conf/test_raw_immcantation_devel.config
@@ -41,7 +41,7 @@ params {
 process{
     // all process with label 'immcantation' will be tested with this container instead.
     withLabel:immcantation{
-        container = 'immcantation/suite:devel'
+        container = 'docker.io/immcantation/suite:devel'
     }
     withName:"DEFINE_CLONES*"{
         ext.args = ['outname':'', 'model':'hierarchical',

--- a/modules/local/gunzip.nf
+++ b/modules/local/gunzip.nf
@@ -5,7 +5,7 @@ process GUNZIP {
     conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'docker.io/biocontainers/biocontainers:v1.2.0_cv1' }"
 
     input:
     tuple val(meta), path(R1), path(R2)

--- a/modules/local/unzip_db.nf
+++ b/modules/local/unzip_db.nf
@@ -5,7 +5,7 @@ process UNZIP_DB {
     conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'docker.io/biocontainers/biocontainers:v1.2.0_cv1' }"
 
     input:
     path(archive)

--- a/nextflow.config
+++ b/nextflow.config
@@ -188,7 +188,7 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        // docker.registry        = 'quay.io'
+        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
@@ -201,8 +201,8 @@ profiles {
         docker.runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
     singularity {
-        conda.enabled = false
-        singularity.enabled = true
+        conda.enabled          = false
+        singularity.enabled    = true
         singularity.autoMounts = true
         conda.enabled          = false
         docker.enabled         = false


### PR DESCRIPTION
Use full URI for all docker containers and revert default registry to quay.io as per template 2.8.

This will make sure all modules are compatible going forward.